### PR TITLE
entry.sh: Do not double-escape env vars when building docker.env

### DIFF
--- a/entry-nosystemd.sh
+++ b/entry-nosystemd.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -11,8 +10,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -26,10 +24,10 @@ function start_udev()
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -59,11 +57,12 @@ function mount_dev()
 
 function init_non_systemd()
 {
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
-		exec tini -sg -- "$CMD" "$@"
+		tini -sg -- "$CMD" "$@" &
+		pid=$!
+		wait "$pid"
 	else
 		echo "Command not found: $1"
 		exit 1

--- a/entry.sh
+++ b/entry.sh
@@ -2,8 +2,7 @@
 
 set -m
 
-hostname "$HOSTNAME" &> /dev/null
-if [[ $? == 0 ]]; then
+if hostname "$HOSTNAME" &> /dev/null; then
 	PRIVILEGED=true
 else
 	PRIVILEGED=false
@@ -13,8 +12,7 @@ function start_udev()
 {
 	if [ "$UDEV" == "on" ]; then
 		if [ "$INITSYSTEM" != "on" ]; then
-			which udevd
-			if [ $? == '0' ]; then
+			if command -v udevd &>/dev/null; then
 				udevd --daemon &> /dev/null
 			else
 				/lib/systemd/systemd-udevd --daemon &> /dev/null
@@ -31,17 +29,17 @@ function start_udev()
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
-	kill $pid
+	kill "$pid"
 }
 
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
 {
-	if [ ${RESIN_DEVICE_UUID:0:7} != ${HOSTNAME:0:7} ]; then
+	if [ "${RESIN_DEVICE_UUID:0:7}" != "${HOSTNAME:0:7}" ]; then
 		# For 1.x Devices only.
 		HOSTNAME="$RESIN_DEVICE_TYPE-${RESIN_DEVICE_UUID:0:7}"
-		echo $HOSTNAME > /etc/hostname
+		echo "$HOSTNAME" > /etc/hostname
 		echo "127.0.1.1 $HOSTNAME" >> /etc/hosts
 		hostname "$HOSTNAME"
 	fi
@@ -74,9 +72,8 @@ function init_systemd()
 	GREEN='\033[0;32m'
 	echo -e "${GREEN}Systemd init system enabled."
 	for var in $(compgen -e); do
-		printf '%q="%q"\n' "$var" "${!var}"
+		printf '%q=%q\n' "$var" "${!var}"
 	done > /etc/docker.env
-	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh
@@ -97,9 +94,8 @@ function init_non_systemd()
 	# trap the stop signal then send SIGTERM to user processes
 	trap signal_handler SIGRTMIN+3 SIGTERM
 
-	CMD=$(which "$1")
 	# echo error message, when executable file doesn't exist.
-	if [ $? == '0' ]; then
+	if CMD=$(command -v "$1" 2>/dev/null); then
 		shift
 		tini -sg -- "$CMD" "$@" &
 		pid=$!
@@ -135,7 +131,7 @@ if [ ! -z "$RESIN" ] && [ ! -z "$RESIN_DEVICE_UUID" ]; then
 		mount_dev
 	fi
 	start_udev
-fi 
+fi
 
 if [ "$INITSYSTEM" = "on" ]; then
 	init_systemd "$@"


### PR DESCRIPTION
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>

Connects to https://github.com/resin-io-library/base-images/pull/478