### PR TITLE
rpi: Install libraspberrypi-bin in Dockerfile

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -43,4 +43,6 @@ done\n\
 rm -r /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
+RUN install_packages libraspberrypi-bin
+
 ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/build.sh
+++ b/build.sh
@@ -9,4 +9,4 @@ mkdir -p $dir/rootfs/usr/bin
 cp qemu-arm-static resin-xbuild $dir/rootfs/usr/bin
 chmod +x $dir/rootfs/usr/bin/qemu-arm-static
 	
-./mkimage.sh -t $REPO:$SUITE --dir=$dir debootstrap --foreign --variant=minbase --keyring=/root/.gnupg/pubring.gpg --arch=armhf --include=sudo,ca-certificates,dirmngr,netbase,curl,procps,libraspberrypi-bin $SUITE $MIRROR
+./mkimage.sh -t $REPO:$SUITE --dir=$dir debootstrap --foreign --variant=minbase --keyring=/root/.gnupg/pubring.gpg --arch=armhf --include=sudo,ca-certificates,dirmngr,netbase,curl,procps $SUITE $MIRROR


### PR DESCRIPTION
Libraspberrypi-bin can not be included in debootstrapping so it should be installed in the rpi Dockerfile

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>