### PR TITLE
packageSources: Add RPI Org package source to Raspbian Buster

### DIFF
--- a/mkimage/debootstrap
+++ b/mkimage/debootstrap
@@ -203,10 +203,7 @@ fi
 	# delete all the apt list files since they're big and get stale quickly
 	rm -rf "$rootfsDir/var/lib/apt/lists"/*
 	# this forces "apt-get update" in dependent images, which is also good
-	if [ $suite != 'buster' ]; then
-		# Raspberry PI Org doesn't have buster yet.
-		echo "deb http://archive.raspberrypi.org/debian $suite main ui" >>  "$rootfsDir/etc/apt/sources.list.d/raspi.list"
-		chroot "$rootfsDir" bash -c 'sudo apt-key adv --batch --keyserver ha.pool.sks-keyservers.net  --recv-key 0x82B129927FA3303E'
-	fi
+	echo "deb http://archive.raspberrypi.org/debian $suite main ui" >>  "$rootfsDir/etc/apt/sources.list.d/raspi.list"
+	chroot "$rootfsDir" bash -c 'sudo apt-key adv --batch --keyserver ha.pool.sks-keyservers.net  --recv-key 0x82B129927FA3303E'
 	mkdir "$rootfsDir/var/lib/apt/lists/partial" # Lucid... "E: Lists directory /var/lib/apt/lists/partial is missing."
 )


### PR DESCRIPTION
Buster support has been added to the RPI Org package repository so we can add it to the raspbian base images.

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>