### PR TITLE
Set platform for rpi-raspbian base images

### DIFF
--- a/automation/build-image.sh
+++ b/automation/build-image.sh
@@ -26,13 +26,14 @@ for suite in $SUITES; do
 
 	rm -rf output
 	mkdir -p output
+
 	docker run --rm --privileged	-e REPO=$REPO \
 									-e SUITE=$suite \
 									-e MIRROR=$MIRROR \
-									-e RESIN_QEMU_VERSION=$QEMU_VERSION \
+									-e RESIN_QEMU_VERSION=$QEMU_RELEASE \
 									-v `pwd`/output:/output raspbian-mkimage
 
-	docker build -t $REPO:$suite output/
+	docker build -t $REPO:$suite --platform=linux/arm/v6 output/
 done
 
 rm -rf qemu* resin-xbuild


### PR DESCRIPTION
This can be done when running the build on new Jenkins, this will be the first one migrated to the new build system.
Here is the link to the new build job https://c678c517a87f5f1e61ae4fc2c5a43503.balena-staging-devices.com/job/balena-rpi-raspbian/

Fixes #104 

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>