### PR TITLE
Remove Jessie from suite list

### DIFF
--- a/automation/jenkins-build.sh
+++ b/automation/jenkins-build.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-export SUITES='jessie stretch buster bullseye'
+export SUITES='stretch buster bullseye'
 export REPO='balenalib/rpi-raspbian'
 LATEST='buster'
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
As release file for Debian Jessie is no longer available in raspbian repository

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>