### PR TITLE
Explicitly install udev in Dockerfile

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -45,7 +45,7 @@ done\n\
 rm -r /var/lib/apt/lists/*' > /usr/sbin/install_packages \
   && chmod 0755 "/usr/sbin/install_packages"
 
-RUN install_packages libraspberrypi-bin
+RUN install_packages libraspberrypi-bin udev
 
 RUN update-ca-certificates -f
 


### PR DESCRIPTION
UDEV env var is not working because udev is not installed in the rpi-raspbian

Change-type: patch
Signed-off-by: Trong Nghia Nguyen <nghiant2710@gmail.com>